### PR TITLE
Support for struct game-state in dashboard inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The project focuses on providing a *game framework system*, *matchmaking*, *real
 
 The goal of the framework is to be have a standard framework & matchmaking solution for all type of games. BEAM directly maps the use cases of a typical game server. So Let's build and run game servers, in a much more intuitive way.
 
-### :warning:  This project is in beta.
 
 Current feature list.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Garuda ships with a javascript client [garudajs](https://github.com/madclaws/gar
 
 def  deps  do
   [
-    {:garuda, "~> 0.2.4"}
+    {:garuda, "~> 0.2.5"}
   ]
 end
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.2.5
+  - Real-time dashboard now supports `struct` game-state, and also shows error reason for unsupported game-states types instead of crashing.
 ## 0.2.4
   - Prevents duplicate joining in matchmaker lobby
   - Allows room_ids with underscores.

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -39,7 +39,7 @@ Garuda leverages phoenix framework completely, should be used in a phoenix proje
 
 def  deps  do
   [
-    {:garuda, "~> 0.2.4"}
+    {:garuda, "~> 0.2.5"}
   ]
 end
 

--- a/lib/monitor/orwell_dashboard.ex
+++ b/lib/monitor/orwell_dashboard.ex
@@ -112,9 +112,19 @@ defmodule Garuda.Monitor.OrwellDashboard do
     |> Enum.map(fn data -> time_diff(data) end)
   end
 
-  defp state_to_string(statemap) do
-    Jason.encode!(statemap, pretty: true)
+  defp state_to_string(statemap) when is_struct(statemap) do
+    Map.from_struct(statemap)
+    |> Jason.encode(pretty: true)
+    |> process_encoding()
   end
+
+  defp state_to_string(statemap) do
+    Jason.encode(statemap, pretty: true)
+    |> process_encoding()
+  end
+
+  defp process_encoding({:ok, state_string}), do: state_string
+  defp process_encoding(_error), do: "Encoding Error, use supported state types"
 
   defp time_diff(room_stats) do
     seconds = (:os.system_time(:milli_seconds) - room_stats["time"]) |> div(1000)

--- a/lib/utils/private_methods.ex
+++ b/lib/utils/private_methods.ex
@@ -1,0 +1,23 @@
+defmodule Garuda.Utils.PrivateMethods do
+  @moduledoc """
+  Some copies of private funtions that are very hard to test with normal flow
+  """
+  defstruct(
+    name: "state_to_string",
+    type: "function"
+  )
+
+  def t_state_to_string(statemap) when is_struct(statemap) do
+    Map.from_struct(statemap)
+    |> Jason.encode(pretty: true)
+    |> process_encoding()
+  end
+
+  def t_state_to_string(statemap) do
+    Jason.encode(statemap, pretty: true)
+    |> process_encoding()
+  end
+
+  defp process_encoding({:ok, state_string}), do: state_string
+  defp process_encoding(_error), do: "Encoding Error, use supported state types"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Garuda.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.2.4"
+  @version "0.2.5"
   def project do
     [
       app: :garuda,

--- a/test/test_functions_test.exs
+++ b/test/test_functions_test.exs
@@ -1,0 +1,27 @@
+defmodule GarudaTest.TestFunctionsTest do
+  @moduledoc false
+  alias Garuda.Utils.PrivateMethods
+  use ExUnit.Case
+
+  @test_map %{
+    name: "state_to_string",
+    type: "function"
+  }
+
+  test "testing normal map state" do
+    state = PrivateMethods.t_state_to_string(@test_map)
+    assert is_binary(state)
+  end
+
+  test "testing struct state" do
+    struct_state = PrivateMethods.__struct__()
+    state = PrivateMethods.t_state_to_string(struct_state)
+    assert is_binary(state)
+  end
+
+  test "testing non-supported state types" do
+    struct_state = {:a, [1, 2, 3]}
+    state = PrivateMethods.t_state_to_string(struct_state)
+    assert is_binary(state)
+  end
+end


### PR DESCRIPTION
# Why?

If the game-room state is a `struct` type, then Orwell dashboard crashes when trying to inspect the game-room's state as i it fails to encode `struct` to `json` directly.

# This change addresses the need by: 

We now explicitly check if the state is a `struct` type, if yes then convert that to `Map`. And also we show error message for unsupported types like Tuple, KeywordList etc.. instead of crashing

# Ticket/Story link
[https://github.com/madclaws/garuda/issues/12](https://github.com/madclaws/garuda/issues/12)